### PR TITLE
update header with relURL to prevent broken links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -64,8 +64,8 @@
         
         {{ if site.Params.backend_redirect.enable }}
         {{ with site.Params.backend_redirect }}
-        <a href="{{ .link_login }}" class="btn btn-sm btn-primary ml-3">{{ .label_login }}</a>
-        <a href="{{ .link_register }}" class="btn btn-sm btn-primary ml-3">{{ .label_register }}</a>
+        <a href="{{ .link_login | relURL }}" class="btn btn-sm btn-primary ml-3">{{ .label_login }}</a>
+        <a href="{{ .link_register | relURL }}" class="btn btn-sm btn-primary ml-3">{{ .label_register }}</a>
           {{ end }}
           {{ end }}
         


### PR DESCRIPTION
Hotfix for header.html

If a `relURL` is not set it will append the link's address to the current url path.

for example

If a user is already on `URL/coming-soon` then clicking on either `login` or `register` will result in `URL/coming-soon/coming-soon/`

Not behaviour we want, and might be why I was seeing 404's in plausible.