### PR TITLE
add twitter card template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,5 +37,6 @@
   {{ partial "analytics-gtag.html" . }}
   {{ end }}
   {{ partial "plausible_head.html" . }}
+  {{ template "_internal/twitter_cards.html" . }}
 
 </head>


### PR DESCRIPTION
Page now supports twitter cards.

This will render a image, title and body text when a Mudmap link is rendered within a tweet.